### PR TITLE
change docroot: WP docker image installs into /usr/src/

### DIFF
--- a/nginx-wordpress/default.conf
+++ b/nginx-wordpress/default.conf
@@ -14,7 +14,7 @@ server {
     error_log /var/log/nginx/error.log;
 
     ## Root and index files.
-    root /var/www/html/web;
+    root /usr/src/wordpress;
     index index.php;
 
     ## See the blacklist.conf file at the parent dir: /etc/nginx.


### PR DESCRIPTION
https://github.com/docker-library/wordpress/blob/master/php5.6/fpm-alpine/Dockerfile#L52